### PR TITLE
Fixes crash when context has been initialized with None

### DIFF
--- a/oboe/__init__.py
+++ b/oboe/__init__.py
@@ -293,7 +293,7 @@ class Context(object):
         return self.__class__(self._md.toString())
 
     def __str__(self):
-        return self._md.toString()
+        return self._md.toString() if self._md else None
 
 class Event(object):
     """An Event is a key/value bag that will be reported to the Tracelyzer."""


### PR DESCRIPTION
This proposed change fixes the following case:

ctx = Context(None)
print str(ctx)

AttributeError: 'NoneType' object has no attribute 'toString'

This has happen to us when using the lower-level API and some variables where not properly initialized in our code. I've fixed the code, but would like to suggest this for added resiliency of the oboe library.
